### PR TITLE
MySQL 8.0.15 Compatibility Update

### DIFF
--- a/b3/querybuilder.py
+++ b/b3/querybuilder.py
@@ -189,7 +189,7 @@ class QueryBuilder(object):
         :param having: The HAVING clause for this select statement.
         :param keywords: Unused at the moment.
         """
-        sql = ['SELECT %s FROM %s' % (self.fieldStr(fields), table)]
+        sql = ['SELECT %s FROM `%s`' % (self.fieldStr(fields), table)]
 
         if where:
             sql.append("WHERE %s" % self.WhereClause(where))


### PR DESCRIPTION
Adding backticks on each side of %s on line 192 made it compatible with MySQL 8.0.15. Haven't tested earlier versions, but it should work.

This error prevented b3 from launching: "ERROR 'Query failed [SELECT * FROM groups WHERE `keyword` = "superadmin" LIMIT 1] None: (1064, u\'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \\\'groups WHERE `keyword` = "superadmin" LIMIT 1\\\' at line 1\')'".